### PR TITLE
Mudando compatibilidade de linux para linux 64 bits

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,7 +203,7 @@
                                             <ul>
                                                 <li><img src="images/check_icon.png" alt="#" /> Programação em R-Educ e C#;
                                                 </li>
-                                                <li><img src="images/check_icon.png" alt="#" /> Windows 8+, MacOS, Linux;
+                                                <li><img src="images/check_icon.png" alt="#" /> Windows 8+, MacOS, Linux 64 Bits;
                                                 </li>
                                                 <li><img src="images/check_icon.png" alt="#" /> Totalmente em português.</li>
                                             </ul>


### PR DESCRIPTION
Unity parou de oferecer suporte ao linux 32 bits. Esse PR troca a compatibilidade de Linux para Linux 64 bits na página inicial